### PR TITLE
컨트렉트 주소 설정 페이지 구현

### DIFF
--- a/config/dev.env.js
+++ b/config/dev.env.js
@@ -3,10 +3,5 @@ const merge = require('webpack-merge')
 const prodEnv = require('./prod.env')
 
 module.exports = merge(prodEnv, {
-  NODE_ENV: '"development"',
-  CONTRACT_ADDRESS: {
-    PXL: '"0x2388b1D14a1B5F26eD694e8edF420E5447F8db7a"',
-    WHITELIST: '"0x4b248E7C083Dd78194a7533EC4fD46775e291319"',
-    SALE: '""'
-  }
+  NODE_ENV: '"development"'
 })

--- a/config/prod.env.js
+++ b/config/prod.env.js
@@ -1,9 +1,4 @@
 'use strict'
 module.exports = {
-  NODE_ENV: '"production"',
-  CONTRACT_ADDRESS: {
-    PXL: '""',
-    WHITELIST: '""',
-    SALE: '""'
-  }
+  NODE_ENV: '"production"'
 }

--- a/src/components/admin/Navi.vue
+++ b/src/components/admin/Navi.vue
@@ -7,6 +7,7 @@
         <b-navbar-nav>
           <router-link active-class="active" class="nav-link" to="/admin/pxl">PXL</router-link>
           <router-link active-class="active" class="nav-link" to="/admin/whitelist">WhiteList</router-link>
+          <router-link active-class="active" class="nav-link" to="/admin/setting">Setting</router-link>
         </b-navbar-nav>
       </b-collapse>
     </b-navbar>

--- a/src/components/admin/pxl/PXL.vue
+++ b/src/components/admin/pxl/PXL.vue
@@ -30,7 +30,7 @@
     methods: {},
     created() {
       web3 = new Web3(web3.currentProvider);
-      this.contract = new web3.eth.Contract(abi, process.env.CONTRACT_ADDRESS.PXL);
+      this.contract = new web3.eth.Contract(abi, localStorage.getItem(this.localStorageKey.PXLAddress));
       web3.eth.getAccounts((err, account) => this.contract.options.from = account[0]);
     },
   }

--- a/src/components/admin/setting/SetAddress.vue
+++ b/src/components/admin/setting/SetAddress.vue
@@ -1,0 +1,62 @@
+<template>
+  <div>
+    <b-card v-bind:title="title"
+            img-top
+            align="left"
+            tag="article">
+      <b-input-group>
+        <b-form-input id="address"
+                      v-model.trim="address"
+                      type="text"
+                      :state="addressState"
+                      placeholder="Address"></b-form-input>
+        <b-input-group-append>
+          <b-btn variant="info"
+                 :disabled="!addressState"
+                 v-on:click="save()">저장
+          </b-btn>
+          <b-btn variant="danger"
+                 :disabled="!addressState"
+                 v-on:click="reset()">초기화
+          </b-btn>
+        </b-input-group-append>
+      </b-input-group>
+    </b-card>
+  </div>
+</template>
+
+<script>
+  export default {
+    name: 'SettingSetAddress',
+    props: ['title', 'storageKey'],
+    computed: {
+      addressState() {
+        return this.address && this.address.length > 0 ? true : false
+      }
+    },
+    data() {
+      return {
+        address: localStorage.getItem(this.storageKey),
+      }
+    },
+    methods: {
+      save() {
+        if(confirm(this.title + '를 저장합니다.')) {
+          localStorage.setItem(this.storageKey, this.address);
+          alert('저장되었습니다')
+        }
+      },
+      reset() {
+        if(confirm(this.title + '를 초기화합니다.')) {
+          this.address = null;
+          localStorage.setItem(this.storageKey, null);
+          alert('초기화되었습니다')
+        }
+      }
+    }
+  }
+</script>
+
+<!-- Add "scoped" attribute to limit CSS to this component only -->
+<style scoped>
+</style>

--- a/src/components/admin/setting/Setting.vue
+++ b/src/components/admin/setting/Setting.vue
@@ -1,0 +1,36 @@
+<template>
+  <div>
+    <SetAddress v-for="address in addressList()"
+                class="component"
+                :key="address.storageKey"
+                :title="address.title"
+                :storageKey="address.storageKey"/>
+  </div>
+</template>
+
+<script>
+  import SetAddress from './SetAddress'
+
+  export default {
+    name: 'Setting',
+    components: {SetAddress},
+    data() {
+      return {
+        addressList: function () {
+          return [
+            {title: 'PXL Contract address', storageKey: this.localStorageKey.PXLAddress},
+            {title: 'Whitelist Contract address', storageKey: this.localStorageKey.whitelistAddress},
+            {title: 'Sale Contract address', storageKey: this.localStorageKey.saleAddress},
+          ]
+        }
+      }
+    }
+  }
+</script>
+
+<!-- Add "scoped" attribute to limit CSS to this component only -->
+<style scoped>
+  .component {
+    margin-bottom: 10px;
+  }
+</style>

--- a/src/components/admin/whitelist/Whitelist.vue
+++ b/src/components/admin/whitelist/Whitelist.vue
@@ -22,7 +22,7 @@
     },
     created() {
       web3 = new Web3(web3.currentProvider);
-      this.contract = new web3.eth.Contract(abi, process.env.CONTRACT_ADDRESS.WHITELIST);
+      this.contract = new web3.eth.Contract(abi, localStorage.getItem(this.localStorageKey.whitelistAddress));
       web3.eth.getAccounts((err, account) => this.contract.options.from = account[0]);
     }
   }

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,15 @@ Vue.config.productionTip = false
 Vue.use(BootstrapVue);
 
 Vue.mixin({
+  data() {
+    return {
+      localStorageKey: {
+        PXLAddress: 'PXLAddress',
+        whitelistAddress: 'whitelistAddress',
+        saleAddress: 'saleAddress',
+      }
+    }
+  },
   methods: {
     getEtherscanURL(hash) {
       if (process.env.NODE_ENV == 'production') {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,8 +3,25 @@ import Router from 'vue-router'
 import Wallet from '@/components/Wallet'
 import PXL from '@/components/admin/pxl/PXL'
 import Whitelist from '@/components/admin/whitelist/Whitelist'
+import Setting from '@/components/admin/setting/Setting'
 
 Vue.use(Router)
+
+const invailidPath = (to, name, addressKey) => {
+  return to.name == name && !localStorage.getItem(addressKey)
+}
+
+const require = (to, from, next) => {
+  const app = this.a.app;
+  if (invailidPath(to, 'PXL', app.localStorageKey.PXLAddress) ||
+    invailidPath(to, 'Whitelist', app.localStorageKey.whitelistAddress) ||
+    invailidPath(to, 'Sale', app.localStorageKey.saleAddress)) {
+    alert('Contract address 를 등록해주세요')
+    return next({path: '/admin/setting'})
+  } else {
+    return next();
+  }
+}
 
 export default new Router({
   mode: 'history',
@@ -21,12 +38,19 @@ export default new Router({
     {
       path: '/admin/pxl',
       name: 'PXL',
-      component: PXL
+      component: PXL,
+      beforeEnter: require
     },
     {
       path: '/admin/whitelist',
       name: 'Whitelist',
-      component: Whitelist
+      component: Whitelist,
+      beforeEnter: require
+    },
+    {
+      path: '/admin/setting',
+      name: 'Setting',
+      component: Setting
     }
   ]
 })


### PR DESCRIPTION
컨트렉트 주소 관리를 env 파일에서 로컬스토리지로 변경하였습니다.
컨트렉트 주소는 Setting 메뉴에서 설정 가능합니다.
또한, 컨트렉트 주소가 등록되지 않으면 해당 컨트렉트를 조작하는 페이지에 진입이 불가능하도록 처리하였습니다.